### PR TITLE
Select all regions by default on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -679,7 +679,7 @@
 
         [...new Set(data.map(elem => getRegion(elem)))].sort().map(region => {
             let selector = document.createElement('a');
-            const selected = region === 'us-east-2';
+            const selected = true;
             selector.className = selected ? 'selector selector-active' : 'selector';
             selector.appendChild(document.createTextNode(region));
             regions.appendChild(selector);


### PR DESCRIPTION
## Summary
- On the default landing page, all regions are now selected instead of only `us-east-2`.

URL-shared links with explicit filter state still override this default.